### PR TITLE
Adding BRNE, Grouping, and MPC policies

### DIFF
--- a/crowd_nav/policy/brne/README.md
+++ b/crowd_nav/policy/brne/README.md
@@ -1,0 +1,23 @@
+# Mixed Strategy Nash Equilibrium for Crowd Navigation
+This directory contains an implementation of the work [Mixed strategy Nash equilibrium for
+crowd navigation (BRNE)](https://arxiv.org/pdf/2403.01537) by Sun. et. al. (2024). The code is adapted from Katie Hughes' [ROS2 implementation](https://github.com/katie-hughes/brne_social_nav), and is designed to run as part of the [ComplexityNav](https://github.com/fluentrobotics/ComplexityNav/tree/master) repository. 
+
+## Code overview
+The implementation is split up into 3 files: **brne.py**, **brne_driver.py**, and **traj_tracker.py**. **brne.py** contains the core BRNE algorithm and helper functions for computing and updating the weights of a trajectory distribution. For further information on the BRNE algorithm, please refer to the [original paper](https://arxiv.org/pdf/2403.01537). **brne_driver.py** contains the driver class `BRNE_Driver` for running BRNE in the ComplexityNav simulation environment. **traj_tracker.py** contains the `TrajTracker` class which enables rollout (cmds --> states) and tracking (states --> cmds) of trajectories for use in the BRNE algorithm.  
+
+## Setup
+Used Python 3.8.5 for development.
+
+## Getting started
+To run BRNE in the ComplexityNav simulation environment, `BRNE_Driver` must be added as a policy. To add the class as a policy, include the following lines in **crowd_nav/policy/policy_factory.py**:
+```
+from crowd_nav.policy.brne.brne_driver import BRNE_Driver
+
+policy_factory['brne'] = BRNE_Driver
+```
+
+This allows the user to run BRNE and visualize the result from the command line within the **crowd_nav** directory as follows:
+
+```
+python test.py --policy brne --model_dir data/output --phase test --visualize --test_case 0
+```

--- a/crowd_nav/policy/brne/brne.py
+++ b/crowd_nav/policy/brne/brne.py
@@ -1,0 +1,310 @@
+########################################################## FUNCTIONS
+import numpy as np
+import numba as nb
+
+# import os
+# os.environ['NUMBA_NUM_THREADS'] = '12'
+# nb.config.NUMBA_NUM_THREADS = 4
+
+rng = np.random.default_rng(1)
+
+
+"""
+BRNE parameters:
+kernel_a1: Control the "straightness" of trajectory samples. Larger the value is, less straight the trajectory sample will be.
+kernel_a2: Control the "width/spreadness" of trajectory samples. Larger the value is, more spread the trajectory samples are.
+cost_a1: Control the safety zone, smaller the value is, more conversative the robot will be.
+cost_a2: Control the safety zone, larger the value is, more conservative the robot will be.
+cost_a3: Control the safety penalty weight, larger the value is, more conservative the robot will be.
+"""
+# kernel_a1 = 0.5
+# kernel_a2 = 0.2
+# cost_a1 = 8.0
+# cost_a2 = 1.0
+# cost_a3 = 20.0
+
+
+@nb.jit(nopython=True, parallel=True)
+def get_kernel_mat_nb(t1list, t2list, kernel_a1, kernel_a2):
+    mat = np.zeros((t1list.shape[0], t2list.shape[0]))
+    for i in nb.prange(t1list.shape[0]):
+        for j in nb.prange(t2list.shape[0]):
+            mat[i][j] = np.exp(-kernel_a1 * (t1list[i] - t2list[j]) ** 2) * kernel_a2
+    return mat.T
+
+
+def mvn_sample_normal(_num_samples, _tsteps, _Lmat):
+    init_samples = rng.standard_normal(size=(_tsteps, _num_samples))
+    new_samples = _Lmat @ init_samples
+    return new_samples.T
+
+
+def get_min_dist(x_trajs, y_trajs):
+    dx_trajs = x_trajs[:, np.newaxis, :] - x_trajs
+    dy_trajs = y_trajs[:, np.newaxis, :] - y_trajs
+    dist_trajs = np.sqrt(dx_trajs ** 2 + dy_trajs ** 2)
+
+    min_dist_trajs = np.min(dist_trajs, axis=2)
+    min_dist_trajs += np.eye(min_dist_trajs.shape[0]) * 1e6
+    min_dist = np.min(min_dist_trajs)
+
+    return min_dist
+
+
+@nb.njit  # ('float64[:, :](float64[:, :])')
+def cholesky_numba(A):
+    n = A.shape[0]
+    L = np.zeros_like(A)
+    for i in range(n):
+        for j in range(i + 1):
+            s = 0
+            for k in range(j):
+                s += L[i][k] * L[j][k]
+
+            if (i == j):
+                L[i][j] = (A[i][i] - s) ** 0.5
+            else:
+                L[i][j] = (1.0 / L[j][j] * (A[i][j] - s))
+    return L
+
+
+# @nb.jit(nopython=True)
+def get_Lmat_nb(train_ts, test_ts, train_noise, kernel_a1, kernel_a2):
+    covmat_11 = get_kernel_mat_nb(train_ts, train_ts, kernel_a1, kernel_a2)
+    covmat_11 += np.diag(train_noise)
+    # print(f"Cmat 11\n{covmat_11}")
+    covmat_12 = get_kernel_mat_nb(test_ts, train_ts, kernel_a1, kernel_a2).T
+    # print(f"Cmat 12\n{covmat_12}")
+    covmat_22 = get_kernel_mat_nb(test_ts, test_ts, kernel_a1, kernel_a2)
+    # print(f"Cmat 22\n{covmat_22}")
+    cov_mat = covmat_22 - covmat_12 @ np.linalg.inv(covmat_11) @ covmat_12.T
+    # print(f"cov mat\n{cov_mat}")
+    cov_mat += np.eye(test_ts.shape[0]) * 1e-06
+    # print(f"cov mat\n{cov_mat}")
+    # print(f"chol mat\n{cholesky_numba(cov_mat)}")
+    return cholesky_numba(cov_mat), cov_mat
+
+
+@nb.jit(nopython=True, parallel=True)
+def costs_nb(trajs_x, trajs_y, num_agents, num_pts, tsteps, cost_a1, cost_a2, cost_a3):
+    vals = np.zeros((num_agents * num_pts, num_agents * num_pts))
+
+    for i in nb.prange(num_pts * num_agents):
+        traj_xi = trajs_x[i]
+        traj_yi = trajs_y[i]
+        for j in nb.prange(num_pts * num_agents):
+            traj_xj = trajs_x[j]
+            traj_yj = trajs_y[j]
+            traj_costs = np.zeros(tsteps)
+            for t in nb.prange(tsteps):
+                dist = (traj_xi[t] - traj_xj[t]) ** 2 + (traj_yi[t] - traj_yj[t]) ** 2
+                traj_costs[t] = 2 - 2 / (1.0 + np.exp(-cost_a1 * np.power(dist, cost_a2)))
+            vals[i, j] = np.max(traj_costs) * cost_a3
+    return vals
+
+
+@nb.jit(nopython=True, parallel=True)
+def weights_update_nb(all_costs, old_weights, index_table, all_pt_index, num_agents, num_pts):
+    weights = old_weights.copy()
+    # print(f"weights shape: {weights.shape[1]}")
+    for i in range(num_agents):
+        row = index_table[i]
+        # other_pt_index = all_pt_index[row[1:], :].ravel()
+        for j in nb.prange(num_pts):
+            cost1 = 0.0
+            idx1 = all_pt_index[row[0], j]
+            for k in nb.prange(num_agents - 1):
+                for l in range(num_pts):
+                    idx2 = all_pt_index[row[k + 1], l]
+                    cost1 += all_costs[idx1, idx2] * weights[row[k + 1], l]
+            cost1 /= (num_agents - 1) * num_pts
+            weights[i, j] = np.exp(-1.0 * cost1)
+        weights[i] /= np.mean(weights[i])
+    return weights
+
+
+@nb.jit(nopython=True, parallel=True)
+def get_index_table(num_agents):
+    index_table = np.zeros((num_agents, num_agents))
+    for i in nb.prange(num_agents):
+        index_table[i][0] = i
+        idx = 1
+        for j in range(num_agents):
+            if i == j:
+                continue
+            index_table[i][idx] = j
+            idx += 1
+    return index_table
+
+# @nb.jit(nopython=True, parallel=True)
+def coll_beck(trajs_y, y_min, y_max):
+    lower_mask = trajs_y > y_min
+    upper_mask = trajs_y < y_max
+    return lower_mask * upper_mask
+
+def brne_nav(xtraj_samples, ytraj_samples, num_agents, tsteps, num_pts, cost_a1, cost_a2, cost_a3, ped_sample_scale, y_min, y_max):
+    index_table = get_index_table(num_agents).astype(int)
+    all_pt_index = np.arange(num_agents * num_pts).reshape(num_agents, num_pts)
+    weights = np.ones((num_agents, num_pts))
+    all_costs = costs_nb(xtraj_samples, ytraj_samples, num_agents, num_pts, tsteps, cost_a1, cost_a2, cost_a3)
+    # print(f"costs nb: {all_costs}")
+    # print(f"{num_agents} {num_pts} {tsteps} {cost_a1} {cost_a2} {cost_a3}")
+    # print(f"input to coll mask {ytraj_samples[0:num_pts].shape}")
+    # coll_mask = coll_beck(ytraj_samples[0:num_pts], y_min, y_max).all(axis=1).astype(float)
+    coll_mask = coll_beck(ytraj_samples, y_min, y_max).all(axis=1).astype(float).reshape(num_agents, num_pts)
+
+    # if we are going out of bounds, coll_mask[0] is all 0s and we will encounter divide by 0 error.
+    if not np.any(coll_mask[0]):
+        return None
+
+    for iter_num in range(10):
+        # print(f"\nWeights {iter_num}\n{weights}")
+        weights = weights_update_nb(all_costs, weights, index_table, all_pt_index, num_agents, num_pts)
+
+    # print(f"\nFinal Weights\n{weights}")
+
+    # for i in range(num_agents):
+    #     agent_weights = weights[i] * coll_mask[i]
+    #     agent_weights /= np.mean(agent_weights)
+    #     weights[i] = agent_weights.copy()
+    agent_weights = weights[0] * coll_mask[0]
+    agent_weights /= np.mean(agent_weights)
+    weights[0] = agent_weights.copy()
+
+    # print(f"\nWeights after masking\n{weights}")
+    return weights
+
+# @nb.jit(nopython=True)
+def get_min_dist(x_trajs, y_trajs):
+    dx_trajs = x_trajs[:,np.newaxis,:] - x_trajs
+    dy_trajs = y_trajs[:,np.newaxis,:] - y_trajs
+    dist_trajs = np.sqrt(dx_trajs**2 + dy_trajs**2)
+
+    min_dist_trajs = np.min(dist_trajs, axis=2)
+    min_dist_trajs += np.eye(min_dist_trajs.shape[0]) * 1e6
+    min_dist = np.min(min_dist_trajs[0])
+    # print('min dist verify: ', np.min(min_dist_trajs[1]))
+
+    return min_dist
+
+##########################################################################################################
+def dyn(st, ut):
+    # print(f"st\n{st.T}")
+    # print(f"ut\n{ut.T}")
+    sdot = np.array([
+        ut[0] * np.cos(st[2]),
+        ut[0] * np.sin(st[2]),
+        ut[1]
+    ])
+    # print(f"Sdot\n{sdot.T}")
+    return sdot
+
+def dyn_step(st, ut, dt):
+    k1 = dt * dyn(st, ut)
+    k2 = dt * dyn(st + k1/2.0, ut)
+    k3 = dt * dyn(st + k2/2.0, ut)
+    k4 = dt * dyn(st + k3, ut)
+
+    return st + (k1 + 2.0 * k2 + 2.0 * k3 + k4) / 6.0
+
+def traj_sim(st, ulist, dt):
+    tsteps = len(ulist)
+    traj = np.zeros((tsteps, 3))
+    for t in range(tsteps):
+        st = dyn_step(st, ulist[t])
+        traj[t] = st.copy()
+    return traj
+
+def traj_sim_essemble(st, ulist, dt):
+    """
+    st.shape = (3, num_samples)
+    ulist = (tsteps, num_samples, 2) 
+    """
+    # Above has been sanity checked
+
+    tsteps = ulist.shape[0]
+    num_samples = ulist.shape[1]
+    assert st.shape[1] == ulist.shape[1]
+
+    traj = np.zeros((tsteps, 3, num_samples))
+
+    for t in range(tsteps):
+        st = dyn_step(st, ulist[t].T, dt)
+        # print(f"Updated state\n{st.T}")
+        traj[t] = st.copy()
+
+    return traj
+
+def get_ulist_essemble(ulist, u1_max, u2_max, num_samples):
+    # square root should be an even number. this is for meshgrid
+    num_essembles_per_dim = int(np.sqrt(num_samples))
+    # empirically, it is more important to have more resolution in linear vs angular
+    num_essembles_per_dim_u1 = int(num_essembles_per_dim * 2)
+    num_essembles_per_dim_u2 = max(int(num_essembles_per_dim / 2),2)
+
+    # print(f"N per u1 {num_essembles_per_dim_u1} per u2 {num_essembles_per_dim_u2}")
+
+    u1_offset = np.minimum(
+        ulist[:,0].min(),
+        u1_max-ulist[:,0].max()
+    )
+
+    # print(f"Ulist :,0 {ulist[:,0]} :,1 {ulist[:,1]}")
+    
+    u2_offset = np.minimum(
+        u2_max+ulist[:,1].min(),
+        u2_max-ulist[:,1].max()
+    )
+
+    # print(f"U1 offset {u1_offset}")
+    # print(f"U2 offset {u2_offset}")
+
+    # ### grid approach
+    # u1_perturbs, u2_perturbs = np.meshgrid(
+    #    np.linspace(-u1_offset, u1_offset, num_essembles_per_dim_u1),
+    #    np.linspace(-u2_offset, u2_offset, num_essembles_per_dim_u1)
+    # )
+
+    # print(f"Linspace u1\n{np.linspace(-u1_offset, u1_offset, num_essembles_per_dim_u1)}")
+    # print(f"Linspace u2\n{np.linspace(-u2_offset, u2_offset, num_essembles_per_dim_u2)}")
+
+    # print(f"U1 perturbs\n{u1_perturbs}")
+    # print(f"U2 perturbs\n{u2_perturbs}")
+
+    ### gaussian
+    # ulist_essemeble = ulist[:,np.newaxis]
+    # print(f"ulist: {ulist}")
+    # print(f"ulist shape: {ulist.shape}")
+    # u_perturbs = np.empty((len(ulist), 4, 2)) 
+    # for i in range(len(ulist)):
+
+    u1_perturbs = np.random.normal(loc= 0,scale=0.25,size=(num_samples,))
+    # u1_perturbs /= -u1_perturbs.min() / (ulist[0][0] - 0.0)
+    u2_perturbs = np.random.normal(loc= 0,scale=0.1,size=(num_samples,))
+    #     # u2_perturbs /= u2_perturbs.max()
+
+    u_perturbs = np.array([
+        u1_perturbs.ravel(), u2_perturbs.ravel()
+    ]).T
+
+    # u_perturbs[i] = u_perturbs_temp
+
+    # print(f"Ulist newaxis {ulist[:,np.newaxis]}")
+
+    # print(f"Ulist\n{ulist}")
+    # print(f"U perturbs\n{u_perturbs}")
+
+        # ulist_essemeble[i] = ulist[i,np.newaxis] + u_perturbs
+    ulist_essemeble = ulist[:,np.newaxis] + u_perturbs
+    # print(f"ulist_essemble pre\n{ulist_essemeble}")
+
+    ulist_essemeble[:,:,0] = np.clip(ulist_essemeble[:,:,0], 0.0, u1_max)
+    ulist_essemeble[:,:,1] = np.clip(ulist_essemeble[:,:,1], -u2_max, u2_max)
+    # print(f"ulist_essemble post\n{ulist_essemeble}")
+
+    assert ulist_essemeble.shape[0] == ulist.shape[0]
+    assert ulist_essemeble.shape[1] == u_perturbs.shape[0] # ORIGINAL
+    # assert ulist_essemeble.shape[1] == u_perturbs.shape[1] 
+    assert ulist_essemeble.shape[2] == ulist.shape[1]
+
+    return ulist_essemeble

--- a/crowd_nav/policy/brne/brne_driver.py
+++ b/crowd_nav/policy/brne/brne_driver.py
@@ -1,0 +1,322 @@
+import numpy as np
+import rvo2
+from crowd_sim.envs.policy.policy import Policy
+from crowd_sim.envs.utils.action import ActionXY, ActionRot
+# from . import brne as brne
+from . import brne as brne
+
+import logging
+import math
+from .traj_tracker import TrajTracker
+import copy
+import time
+from crowd_nav.utils.data_collect import DATA
+
+
+
+class BRNE_Driver(Policy):
+
+    def __init__(self):
+        super().__init__()
+        self.trainable = False
+        self.name = 'brne'
+        self.kinematics = 'unicycle'
+        self.multiagent_training = False
+        self.sim = None
+        self.plan_steps = 4
+        self.num_samples = 4
+        self.a1 = 10
+        self.a2 = 10
+        self.a3 = 10
+        self.brne_activate_threshold = 12
+        self.dt = 0.25
+        self.nominal_vel = 1.0
+        self.max_lin_vel = 1.0
+        self.max_ang_vel = 0.3
+        self.close_stop_threshold = 0.5
+        self.cost_a1 = 7.0
+        self.cost_a2 = 7.0
+        self.cost_a3 = 5.0
+        self.ped_sample_scale = 0.1
+        self.corridor_y_min = -12.0
+        self.corridor_y_max = 12.0
+        self.cmd_tracker = TrajTracker(dt=self.dt, max_lin_vel=self.max_lin_vel, max_ang_vel=self.max_ang_vel)   # the class that converts waypoints to control commands
+        self.robot_goal = None
+        self.cmd_counter = 0
+        self.open_space_velocity = 0.6
+        self.num_agents = 13 # maximum number of agents considered
+        tlist = np.arange(self.plan_steps) * self.dt
+        train_ts = np.array([tlist[0]])
+        train_noise = np.array([1e-04])
+        test_ts = tlist
+        self.kernel_a1 = 0.2
+        self.kernel_a2 = 0.2
+        self.cov_Lmat, self.cov_mat = brne.get_Lmat_nb(train_ts, test_ts, train_noise, self.kernel_a1, self.kernel_a2)
+        self.data_tracker = DATA()
+
+
+
+
+    def configure(self, config):
+        assert True
+
+
+    def brne_cb(self, state):
+        self_state = state.robot_state
+        self.robot_goal = np.array([self_state.gx, self_state.gy])
+
+        ped_info_list = []
+        dists2peds = []
+
+        # we go through each perceived pedestrian and save the information
+        for ped in state.human_states:
+            dist2ped = np.sqrt((self_state.px-ped.px)**2 + (self_state.py-ped.py)**2)
+            if dist2ped < self.brne_activate_threshold:  # only consider pedestrians within the activate threshold
+                ped_info = np.array([
+                    ped.px, ped.py, ped.vx, ped.vy
+                ])
+                ped_info_list.append(ped_info)
+
+                dists2peds.append(dist2ped)
+
+        ped_info_list = np.array(ped_info_list)
+        self.num_peds = len(ped_info_list)
+
+        dists2peds = np.array(dists2peds)
+
+        # compute how many pedestrians we are actually interacting with
+        num_agents = np.minimum(self.num_peds+1, self.num_agents)
+
+        # print(f"CMD COUNTER: {self.cmd_counter}")
+
+        # self.cmd_counter restricts the BRNE replanning to self.plan_steps
+        # if there are other agents in the scene 
+        if self.cmd_counter == 0 and num_agents > 1:
+            ped_indices = np.argsort(dists2peds)[:num_agents-1]  # we only pick the N closest pedestrian to interact with
+            robot_state = np.array([self_state.px,self_state.py,self_state.theta])
+
+            x_pts = brne.mvn_sample_normal((num_agents-1) * self.num_samples, self.plan_steps, self.cov_Lmat)
+            y_pts = brne.mvn_sample_normal((num_agents-1) * self.num_samples, self.plan_steps, self.cov_Lmat)
+
+            # ctrl space configuration here
+            xtraj_samples = np.zeros((
+                num_agents * self.num_samples, self.plan_steps
+            ))
+            ytraj_samples = np.zeros((
+                num_agents * self.num_samples, self.plan_steps
+            ))
+
+            closest_dist2ped = 100.0
+            closest_ped_pos = np.zeros(2) + 100.0
+            for i, ped_id in enumerate(ped_indices):
+                ped_pos = ped_info_list[ped_id][:2]
+                ped_vel = ped_info_list[ped_id][2:]
+                speed_factor = np.linalg.norm(ped_vel)
+                ped_xmean = ped_pos[0] + np.arange(self.plan_steps) * self.dt * ped_vel[0]
+                ped_ymean = ped_pos[1] + np.arange(self.plan_steps) * self.dt * ped_vel[1]
+
+
+                xtraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] = \
+                    x_pts[i*self.num_samples : (i+1)*self.num_samples] * speed_factor + ped_xmean
+                ytraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] = \
+                    y_pts[i*self.num_samples : (i+1)*self.num_samples] * speed_factor + ped_ymean
+                
+                dist2ped = np.linalg.norm([
+                    robot_state[:2] - ped_pos[:2] # questionable translation from ros
+                ])
+                if dist2ped < closest_dist2ped:
+                    closest_dist2ped = dist2ped
+                    closest_ped_pos = ped_pos.copy()
+
+
+            st = copy.copy(robot_state)
+
+            goal = np.array([self_state.gx, self_state.gy])
+
+            angle = st[2]
+            if angle > 0.0:
+                theta_a = angle - np.pi/2
+            else:
+                theta_a = angle + np.pi/2
+            axis_vec = np.array([
+                np.cos(theta_a), np.sin(theta_a)
+            ])  
+
+            # axis_vec = np.array([
+            #     np.cos(angle), np.sin(angle)
+            # ])
+            vec2goal = np.array([goal[0] - st[0], goal[1] - st[1]])
+            # logging.info("vec2goal: {}".format(vec2goal))
+            dist2goal = np.linalg.norm(vec2goal)
+            proj_len = (axis_vec @ vec2goal) / (vec2goal @ vec2goal) * dist2goal
+            # proj_len = (np.dot(axis_vec, vec2goal)) / (np.dot(vec2goal, vec2goal)) * dist2goal
+            # logging.info("proj_len: {}".format(proj_len))
+            # if (proj_len == 0):
+            #     proj_len = 0.001
+            radius = 0.5 * dist2goal / proj_len 
+            # print(f"radius: {radius}")
+
+            if angle > 0.0:
+                ut = np.array([self.nominal_vel, -self.nominal_vel/radius])
+            else:
+                ut = np.array([self.nominal_vel, self.nominal_vel/radius])
+            nominal_cmds = np.tile(ut, reps=(self.plan_steps,1))
+            # self.get_logger().info(f"Nominal commands {nominal_cmds.shape}\n{nominal_cmds}")
+            ulist_essemble = brne.get_ulist_essemble(
+                nominal_cmds, self.max_lin_vel, self.max_ang_vel, self.num_samples
+            )
+
+            tiles = np.tile(robot_state, reps=(self.num_samples,1)).T
+
+            traj_essemble = brne.traj_sim_essemble( 
+                tiles,
+                ulist_essemble,
+                self.dt
+            )
+
+            xtraj_samples[0:self.num_samples] = traj_essemble[:,0,:].T
+            ytraj_samples[0:self.num_samples] = traj_essemble[:,1,:].T
+
+
+            # generate sample weight mask for the closest pedestrian
+            robot_xtrajs = traj_essemble[:,0,:].T
+            robot_ytrajs = traj_essemble[:,1,:].T
+            robot_samples2ped = (robot_xtrajs - closest_ped_pos[0])**2 + (robot_ytrajs - closest_ped_pos[1])**2
+            robot_samples2ped = np.min(np.sqrt(robot_samples2ped), axis=1)
+            safety_mask = (robot_samples2ped > self.close_stop_threshold).astype(float)
+            safety_samples_percent = safety_mask.mean() * 100
+            # self.get_logger().debug('percent of safe samples: {:.2f}%'.format(safety_samples_percent))
+            # self.get_logger().debug('dist 2 ped: {:.2f} m'.format(closest_dist2ped))
+
+            
+            self.close_stop_flag = False
+            if np.max(safety_mask) == 0.0:
+                safety_mask = np.ones_like(safety_mask)
+                self.close_stop_flag = True
+            # self.get_logger().debug('safety mask: {}'.format(safety_mask))
+
+            # BRNE OPTIMIZATION HERE !!!
+            weights = brne.brne_nav(
+                xtraj_samples, ytraj_samples,
+                num_agents, self.plan_steps, self.num_samples,
+                self.cost_a1, self.cost_a2, self.cost_a3, self.ped_sample_scale,
+                self.corridor_y_min, self.corridor_y_max
+            )
+
+            # print(f"weights: {weights}")
+            if (np.mean(weights[0]) != 0):
+                weights[0] /= np.mean(weights[0])
+            
+            print(f"weight[0]: {weights[0]}")
+            opt_cmds_1 = np.mean(ulist_essemble[:,:,0] * weights[0], axis=1)
+            opt_cmds_2 = np.mean(ulist_essemble[:,:,1] * weights[0], axis=1)
+            # logging.info("cmds: {}".format(np.mean(opt_cmds_1)))
+
+            self.cmds = np.array([opt_cmds_1, opt_cmds_2]).T
+            self.cmds_traj = self.cmd_tracker.sim_traj(robot_state, self.cmds)
+
+            ped_trajs_x = np.zeros((num_agents-1, self.plan_steps))
+            ped_trajs_y = np.zeros((num_agents-1, self.plan_steps))
+            for i in range(num_agents-1):
+                ped_trajs_x[i] = \
+                    np.mean(xtraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] * weights[i+1][:,np.newaxis], axis=0)
+                ped_trajs_y[i] = \
+                    np.mean(ytraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] * weights[i+1][:,np.newaxis], axis=0)
+            
+
+        # if the ego agent is the only in the scene
+        elif num_agents == 1:
+            print("no peds")
+            self.close_stop_flag = False
+            robot_state = self_state
+            st = np.array([robot_state.position[0], robot_state.position[1], robot_state.theta])
+            print(f"ROBOT THETA: {st[2]}")
+            goal = np.array([self_state.gx,self_state.gy])
+            theta_a = st[2]
+            if st[2] > 0.0:
+                theta_a = st[2] - np.pi/2
+            elif st[2] < 0.0:
+                theta_a = st[2] + np.pi/2
+
+            axis_vec = np.array([
+                np.cos(theta_a), np.sin(theta_a)
+            ])
+            # rot = [[np.cos(np.pi/2), -np.sin(np.pi/2)],
+            #        [np.sin(np.pi/2), np.cos(np.pi/2)]]
+                   
+            # axis_vec = rot @ axis_vec
+
+            # TODO: There is a difference between what the robot thinks is 0 heading and what BRNE thinks is 0 heading
+            # I think that BRNE thinks right is 0 and crowdnav thinks up is 0.
+            ##
+            vec2goal = np.array([goal[0] - st[0], goal[1] - st[1]])
+
+            dist2goal = np.linalg.norm(vec2goal)
+            proj_len = (axis_vec @ vec2goal) / (vec2goal @ vec2goal) * dist2goal
+            # print(f"proj_len: {proj_len}")
+            # print(f"dist2goal: {dist2goal}")
+            if (proj_len == 0):
+                proj_len = 10^(-10)
+            radius = 0.5 * dist2goal / proj_len
+
+            if st[2] > 0.0:
+                ut = np.array([self.nominal_vel, -self.nominal_vel/radius])
+            elif st[2] < 0.0:
+                ut = np.array([self.nominal_vel, self.nominal_vel/radius])
+            else:
+                ut = np.array([self.nominal_vel, 0.0])
+                
+            nominal_cmds = np.tile(ut, reps=(self.plan_steps,1))
+
+            nominal_vel = self.open_space_velocity
+
+            ulist_essemble = brne.get_ulist_essemble(
+                nominal_cmds, nominal_vel, self.max_ang_vel, self.num_samples
+            )
+            traj_essemble = brne.traj_sim_essemble(
+                np.tile(st, reps=(self.num_samples,1)).T,
+                ulist_essemble,
+                self.dt
+            )
+
+            end_pose_essemble = traj_essemble[-1, 0:2, :].T
+            dists2goal_essemble = np.linalg.norm(end_pose_essemble - goal, axis=1)
+            opt_cmds = ulist_essemble[:, np.argmin(dists2goal_essemble), :]
+
+            self.cmds = opt_cmds
+            self.cmds_traj = self.cmd_tracker.sim_traj(st, self.cmds)
+
+            if self.cmd_counter >= self.plan_steps:
+                self.cmd_counter = 0
+
+            self.define_trajectory(self.cmds_traj[:,0], self.cmds_traj[:,1])
+            
+        x_cmd = float(self.cmds[self.cmd_counter][0])
+        rot_cmd = float(self.cmds[self.cmd_counter][1])
+        print(f"x, rot: {x_cmd, rot_cmd}")
+
+        self.cmd_counter += 1
+        if self.cmd_counter >= self.plan_steps:
+            self.cmd_counter = 0
+        return ActionRot(x_cmd, rot_cmd)
+
+        # print(self.cmds_traj)
+
+    def predict(self, state, border=None, radius=None, baseline=None):
+        start_time = time.time()
+        cmd = self.brne_cb(state)
+        tim = time.time() - start_time
+        self.data_tracker.update_data(state,tim)
+        # print(f"Single iteration runtime: {time.time() - start_time}")
+        return cmd
+
+
+    def define_trajectory(self, xs, ys):
+        p = []
+
+        for x,y in zip(xs, ys):
+            pose = [x, y]
+            p.append(pose)
+
+        # logging.info("p: {}".format(p))
+        return p

--- a/crowd_nav/policy/brne/traj_tracker.py
+++ b/crowd_nav/policy/brne/traj_tracker.py
@@ -1,0 +1,131 @@
+import numpy as np
+
+
+class TrajTracker():
+    def __init__(self, dt, max_lin_vel=0.6, max_ang_vel=1.2):
+        self.dt = dt
+        self.ad = -5  # range between -2 to -10, prfer to be smaller than -5
+        self.R = np.diag(np.array([1.0, 2.0]))
+        self.umax = np.array([max_lin_vel, max_ang_vel])
+        # self.umin = -1.0 * self.umax
+        self.umin = np.array([0.0, -max_ang_vel])
+
+    def wrap(self, a):
+        return (a + np.pi) % (2 * np.pi) - np.pi
+
+    def dyn(self, st, ut):
+        xdot = ut[0] * np.cos(st[2])
+        ydot = ut[0] * np.sin(st[2])
+        thdot = ut[1]
+        sdot = np.array([xdot, ydot, thdot])
+        return sdot
+
+    def dyn_step(self, st, ut):
+        k1 = self.dyn(st, ut) * self.dt
+        k2 = self.dyn(st+k1/2, ut) * self.dt
+        k3 = self.dyn(st+k2/2, ut) * self.dt
+        k4 = self.dyn(st+k3, ut) * self.dt
+        st_new = st + (k1 + 2*k2 + 2*k3 + k4) / 6
+        st_new[2] = self.wrap(st_new[2])
+        return st_new
+
+    def sim_traj(self, s0, ulist):
+        tsteps = len(ulist) + 1
+        ndim = len(s0)
+        traj = np.zeros((tsteps, ndim))
+        traj[0] = s0.copy()
+        st = s0.copy()
+        for t in range(1, tsteps):
+            st = self.dyn_step(st, ulist[t-1])
+            traj[t] = st.copy()
+        return traj.copy()
+
+    def l1(ref_st, st):
+        diff_s = st - ref_st
+        val = np.sum(np.square(diff_s))
+        return val
+
+    def dl1ds(self, ref_st, st):
+        diff_s = st - ref_st
+        diff_s[2] = self.wrap(diff_s[2])
+        return 2 * diff_s
+
+    def rho_dyn(self, rhot, st, ut, ref_st):
+        A = np.array([
+            [0, 0, ut[0] * -np.sin(st[2])],
+            [0, 0, ut[0] * np.cos(st[2])],
+            [0, 0, 0]
+        ])
+        return A.T @ rhot + self.dl1ds(ref_st, st)
+
+    def rho_step(self, rhot, st, ut, ref_st):
+        k1 = self.rho_dyn(rhot, st, ut, ref_st) * self.dt
+        k2 = self.rho_dyn(rhot+k1/2, st, ut, ref_st) * self.dt
+        k3 = self.rho_dyn(rhot+k2/2, st, ut, ref_st) * self.dt
+        k4 = self.rho_dyn(rhot+k3, st, ut, ref_st) * self.dt
+        rhot_new = rhot + (k1 + 2*k2 + 2*k3 + k4) / 6
+        return rhot_new
+
+    def rho_sim(self, rhoT, slist, ulist, ref_slist):
+        tsteps = len(slist)
+        ndim = len(rhoT)
+        rho_traj = np.zeros((tsteps, ndim))
+        rho_traj[0] = rhoT.copy()
+        rhot = rhoT.copy()
+        for t in range(1, tsteps):
+            rhot = self.rho_step(rhot, slist[t-1], ulist[t-1], ref_slist[t-1])
+            rho_traj[t] = rhot.copy()
+        return rho_traj.copy()
+
+    def compute_u2(self, st, ut, rhot, R, ad, umin, umax):
+        hx = np.array([
+            [np.cos(st[2]), 0],
+            [np.sin(st[2]), 0],
+            [0, 1]
+        ])
+        temp_vec = hx.T @ rhot
+        sig = np.outer(temp_vec, temp_vec)
+        u2 = np.linalg.solve(sig + R.T, sig@ut + hx.T@rhot * ad)
+        return np.clip(u2, umin, umax)
+
+    def compute_u2list(self, slist, ulist, rho_list, R, ad, umin, umax):
+        u2list = np.zeros_like(ulist)
+        for i, (st, ut, rhot) in enumerate(zip(slist, ulist, rho_list)):
+            u2list[i] = self.compute_u2(st, ut, rhot, R, ad, umin, umax)
+        return u2list.copy()
+
+    def get_controls(self, s0, ref_traj, udef):
+        isac_horizon = 5
+
+        sim_tsteps = ref_traj.shape[0]
+        recon_ref_traj = np.concatenate([ref_traj, np.tile(ref_traj[-1], (isac_horizon, 1))])
+
+        ref_slist = recon_ref_traj.copy()
+        ref_thlist = np.arctan2(ref_slist[1:, 1] - ref_slist[:-1, 1], ref_slist[1:, 0] - ref_slist[:-1, 0])
+        ref_thlist = self.wrap(ref_thlist)
+        ref_thlist = np.array([*ref_thlist, ref_thlist[-1]])
+        ref_slist = np.concatenate([ref_slist, ref_thlist[:, np.newaxis]], axis=1)
+
+        ulist0 = np.zeros((isac_horizon, 2)) + udef  # np.array([0.0, 0.0])
+        s_curr = s0.copy()
+        opt_ulist = np.zeros((sim_tsteps-1, 2))
+        opt_traj = np.zeros((sim_tsteps, 3))
+        opt_traj[0] = s0.copy()
+
+        for sim_t in range(sim_tsteps-1):
+            ulist = ulist0.copy()
+
+            curr_ref_slist = ref_slist[sim_t: sim_t + isac_horizon]
+            slist = self.sim_traj(s_curr, ulist)
+            # tlist = np.arange(isac_horizon) * self.dt + sim_t * self.dt
+            rhoT = np.zeros_like(slist[-1])
+            rho_list_back = self.rho_sim(rhoT, slist[::-1], ulist[::-1], curr_ref_slist[::-1])
+            rho_list = rho_list_back[::-1]
+            u2list = ulist.copy()
+            u2list[0] = self.compute_u2(slist[0], ulist[0], rho_list[0], self.R, self.ad, self.umin, self.umax)
+
+            opt_ulist[sim_t] = u2list[0].copy()
+            s_curr = self.sim_traj(s_curr, u2list)[1]
+            opt_traj[sim_t+1] = s_curr.copy()
+
+        return opt_ulist, opt_traj

--- a/crowd_nav/policy/topology_mpc/README.md
+++ b/crowd_nav/policy/topology_mpc/README.md
@@ -1,0 +1,29 @@
+# Topology-preserving MPCs
+This directory contains various MPCs which seek to preserve some global topological plan. There are 3 separate files: **brne_wind.py**, **brne_wind_cv.py**, **cv_wind.py**. All implementations are built on top of the implementations found in the **vecMPC** directory, and achieve the topological constraints using the `predict_wind`, `winding_reject`, and `winding_distribution` methods.
+
+### brne_wind.py
+This MPC performs a trajectory rollout using the BRNE implementation adapted to ComplexityNav. The winding numbers of the returned trajectories are used as the topological constraint.
+
+### brne_wind_cv.py
+This MPC performs a constant-velocity pedestrian trajectory rollout and the BRNE implementation adapted to ComplexityNav for the robot. The winding numbers of the returned trajectories are used as the topological constraint.
+
+
+### cv_wind.py
+This MPC performs a constant-velocity trajectory rollout. The winding numbers of the returned trajectories are used as the topological constraint.
+
+## Setup
+Used Python 3.8.5 for development. 
+
+## Getting started
+To run BRNE in the ComplexityNav simulation environment, each MPC class must be added as a policy. To add the class as a policy, include the following lines in **crowd_nav/policy/policy_factory.py**:
+```
+from crowd_nav.policy.topology_mpc.<FILE> import <CLASS>
+
+policy_factory['<CONTROLLER_NAME>'] = <CLASS>
+```
+
+This allows the user to run BRNE and visualize the result from the command line within the **crowd_nav** directory as follows:
+
+```
+python test.py --policy <CONTROLLER_NAME> --model_dir data/output --phase test --visualize --test_case 0
+```

--- a/crowd_nav/policy/topology_mpc/brne_wind.py
+++ b/crowd_nav/policy/topology_mpc/brne_wind.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python
+
+"""Collection of examples that demonstrate the functionality of
+distributed-potential-ilqr in various scenarios.
+
+Including:
+ - single unicycle
+ - single quadcopter (6D)
+ - two quads with one human
+ - random multi-agent simulation
+
+"""
+
+import rvo2
+from crowd_sim.envs.utils.action import ActionXY, ActionRot
+
+import numpy as np
+import matplotlib.pyplot as plt
+from crowd_sim.envs.policy.policy import Policy
+from crowd_nav.policy.vecMPC.controller_wind import vecMPC
+
+from crowd_nav.policy.brne import brne as brne
+
+import logging
+import math
+from crowd_nav.policy.brne.traj_tracker import TrajTracker
+import copy
+import time
+import itertools
+
+from crowd_nav.utils.data_collect import DATA
+
+# import dpilqr
+# import scenarios
+
+π = np.pi
+g = 9.80665
+
+
+class BRNEWIND(Policy):
+
+    def __init__(self,config):
+        super().__init__()
+        self.name = 'brne_wind'
+        self.trainable = False
+        self.U = None
+        self.MPC = vecMPC(config)
+        self.kinematics = 'holonomic'
+        self.multiagent_training = False
+        self.sim = None
+        self.plan_steps = 5 # must be <= 7 for MPC
+        self.num_samples = 5
+        self.a1 = 10
+        self.a2 = 10
+        self.a3 = 10
+        self.brne_activate_threshold = 12
+        self.dt = 0.25
+        self.nominal_vel = 1.0
+        self.max_lin_vel = 1.0
+        self.max_ang_vel = 0.3
+        self.close_stop_threshold = 0.5
+        self.cost_a1 = 2.0
+        self.cost_a2 = 7.0
+        self.cost_a3 = 5.0
+        self.ped_sample_scale = 0.1
+        self.corridor_y_min = -12.0
+        self.corridor_y_max = 12.0
+        self.cmd_tracker = TrajTracker(dt=self.dt, max_lin_vel=self.max_lin_vel, max_ang_vel=self.max_ang_vel)   # the class that converts way points to control commands
+        self.robot_goal = None
+        self.cmd_counter = 0
+        self.open_space_velocity = 0.6
+        self.num_agents = 13 # maximum number of agents considered
+        tlist = np.arange(self.plan_steps) * self.dt
+        train_ts = np.array([tlist[0]])
+        train_noise = np.array([1e-04])
+        test_ts = tlist
+        self.kernel_a1 = 0.2
+        self.kernel_a2 = 0.2
+        self.cov_Lmat, self.cov_mat = brne.get_Lmat_nb(train_ts, test_ts, train_noise, self.kernel_a1, self.kernel_a2)
+        self.data_tracker = DATA()
+
+    def configure(self, config):
+        assert True
+
+
+    # calculate the winding number w.r.t. one human
+    def calc_w(self,rob_x, rob_y, hum_x, hum_y):
+        w = 0
+
+        for i in range(1, len(rob_x)):
+            theta1 = np.arctan2(rob_y[i] - hum_y[i], rob_x[i] - hum_x[i])
+            theta2 = np.arctan2(rob_y[i-1] - hum_y[i-1], rob_x[i-1] - hum_x[i-1])
+            w += theta1-theta2
+
+        return w
+
+
+    # compute distribution over winding vectors based on BRNE rollout
+    def wind_distribution(self, state, x_traj_samples, y_traj_samples, weights):
+        wind_matrix = np.zeros((self.num_samples, len(state.human_states), self.num_samples)) # (robot sample) x (human index) x (human sample)
+        weight_matrix = np.zeros((self.num_samples, len(state.human_states), self.num_samples))
+        # print(f"weights size: {weights.shape}")
+
+
+        for i in range(self.num_samples): # for each robot traj sample
+            for j in range(len(state.human_states)): # for each human
+                for k in range(self.num_samples): # for each human traj sample
+                    w = self.calc_w(x_traj_samples[i], y_traj_samples[i], x_traj_samples[(j+1)*(self.num_samples) + k], y_traj_samples[(j+1)*(self.num_samples) + k])
+                    if (w < 0):
+                        wind_matrix[i,j,k] = -1
+                    elif (w > 0):
+                        wind_matrix[i,j,k] = 1
+
+                    weight_matrix[i,j,k] = weights[0, i] + weights[1+j, k]
+        
+        combinations = list(itertools.product(range(0, self.num_samples), repeat=(len(state.human_states)+1)))
+        wind_vecs = np.zeros((len(combinations), len(state.human_states)))
+        all_weights = np.zeros(len(combinations))
+        for i in range(len(combinations)):
+            for j in range(1, len(state.human_states)+1):
+                wind_vecs[i][j-1] = wind_matrix[combinations[i][0]][j-1][combinations[i][j]]
+                all_weights[i] += weight_matrix[combinations[i][0]][j-1][combinations[i][j]] # note that this considers the robot sample weight twice
+
+
+        wind_list = []
+        wind_list.append(wind_vecs[0])
+
+        weight_list = []
+        weight_list.append(all_weights[0])
+
+        is_in = False
+
+        for i in range(1,(len(wind_vecs))):
+            vec = wind_vecs[i]
+            for j in range(len(wind_list)):
+                if (vec == wind_list[j]).all():
+                    weight_list[j] += all_weights[i]
+                    is_in = True
+                    break
+
+            if not is_in:
+                wind_list.append(vec)
+                weight_list.append(all_weights[i])
+            else:
+                is_in = False
+        
+        weight_array = np.array(weight_list)
+        weight_norm = np.linalg.norm(weight_array)
+        weight_array = weight_array/weight_norm
+
+        # print(f"wind_list: {wind_list}")
+        print(f"weight_array: {weight_array}")
+        return wind_list, weight_array
+                
+
+
+        
+
+    def brne_cb(self, state):
+        self_state = state.robot_state
+        self.robot_goal = np.array([self_state.gx, self_state.gy])
+
+        # BEGIN BRNE
+        ped_info_list = []
+        dists2peds = []
+
+        # we go through each perceived pedestrian and save the information
+        for ped in state.human_states:
+            dist2ped = np.sqrt((self_state.px-ped.px)**2 + (self_state.py-ped.py)**2)
+            if dist2ped < self.brne_activate_threshold:  # only consider pedestrians within the activate threshold
+                ped_info = np.array([
+                    ped.px, ped.py, ped.vx, ped.vy
+                ])
+                ped_info_list.append(ped_info)
+
+                dists2peds.append(dist2ped)
+
+        ped_info_list = np.array(ped_info_list)
+        self.num_peds = len(ped_info_list)
+
+        dists2peds = np.array(dists2peds)
+
+        # compute how many pedestrians we are actually interacting with
+        num_agents = np.minimum(self.num_peds+1, self.num_agents)
+
+        print(f"CMD COUNTER: {self.cmd_counter}")
+
+
+
+        if self.cmd_counter == 0 and num_agents > 1:
+            # print("peds")
+
+            ped_indices = np.argsort(dists2peds)[:num_agents-1]  # we only pick the N closest pedestrian to interact with
+            robot_state = np.array([self_state.px,self_state.py,self_state.theta])
+
+            x_pts = brne.mvn_sample_normal((num_agents-1) * self.num_samples, self.plan_steps, self.cov_Lmat)
+            y_pts = brne.mvn_sample_normal((num_agents-1) * self.num_samples, self.plan_steps, self.cov_Lmat)
+
+            # self.get_logger().info(f'X and y pts shape {x_pts.shape} {y_pts.shape}')
+
+            # ctrl space configuration here
+            xtraj_samples = np.zeros((
+                num_agents * self.num_samples, self.plan_steps
+            ))
+            ytraj_samples = np.zeros((
+                num_agents * self.num_samples, self.plan_steps
+            ))
+
+            closest_dist2ped = 100.0
+            closest_ped_pos = np.zeros(2) + 100.0
+            for i, ped_id in enumerate(ped_indices):
+                ped_pos = ped_info_list[ped_id][:2]
+                ped_vel = ped_info_list[ped_id][2:]
+                speed_factor = np.linalg.norm(ped_vel)
+                ped_xmean = ped_pos[0] + np.arange(self.plan_steps) * self.dt * ped_vel[0]
+                ped_ymean = ped_pos[1] + np.arange(self.plan_steps) * self.dt * ped_vel[1]
+
+
+                xtraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] = \
+                    x_pts[i*self.num_samples : (i+1)*self.num_samples] * speed_factor + ped_xmean
+                ytraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] = \
+                    y_pts[i*self.num_samples : (i+1)*self.num_samples] * speed_factor + ped_ymean
+                
+                dist2ped = np.linalg.norm([
+                    robot_state[:2] - ped_pos[:2] # questionable translation from ros
+                ])
+                if dist2ped < closest_dist2ped:
+                    closest_dist2ped = dist2ped
+                    closest_ped_pos = ped_pos.copy()
+
+
+            st = copy.copy(robot_state)
+
+            # if self.robot_goal is None:
+            #     goal = np.array([6.0, 0.0])
+            # else:
+            #     goal = self.robot_goal[:2]
+
+            goal = np.array([self_state.gx, self_state.gy])
+            # logging.info("goal: {}".format(goal))
+
+            angle = st[2]
+            if angle > 0.0:
+                theta_a = angle - np.pi/2
+            else:
+                theta_a = angle + np.pi/2
+            axis_vec = np.array([
+                np.cos(theta_a), np.sin(theta_a)
+            ])  
+
+            vec2goal = np.array([goal[0] - st[0], goal[1] - st[1]])
+            dist2goal = np.linalg.norm(vec2goal)
+            proj_len = (axis_vec @ vec2goal) / (vec2goal @ vec2goal) * dist2goal
+            radius = 0.5 * dist2goal / proj_len 
+            # print(proj_len)
+
+            # print(f"radius: {radius}")
+            if angle > 0.0:
+                ut = np.array([self.nominal_vel, -self.nominal_vel/radius])
+            else:
+                ut = np.array([self.nominal_vel, self.nominal_vel/radius])
+            nominal_cmds = np.tile(ut, reps=(self.plan_steps,1))
+            # self.get_logger().info(f"Nominal commands {nominal_cmds.shape}\n{nominal_cmds}")
+            ulist_essemble = brne.get_ulist_essemble(
+                nominal_cmds, self.max_lin_vel, self.max_ang_vel, self.num_samples
+            )
+            # print("hello")
+            # self.get_logger().info(f"ulist {ulist_essemble.shape}\n{ulist_essemble}")
+            # print(f"essemble {ulist_essemble}")
+            tiles = np.tile(robot_state, reps=(self.num_samples,1)).T
+
+            traj_essemble = brne.traj_sim_essemble( 
+                tiles,
+                ulist_essemble,
+                self.dt
+            )
+
+            # print(traj_essemble)
+            # logging.info("essemble: {}".format(traj_essemble))
+
+            xtraj_samples[0:self.num_samples] = traj_essemble[:,0,:].T
+            ytraj_samples[0:self.num_samples] = traj_essemble[:,1,:].T
+            # print(f"xtraj_samples: {xtraj_samples.shape}")
+
+            # generate sample weight mask for the closest pedestrian
+            robot_xtrajs = traj_essemble[:,0,:].T
+            robot_ytrajs = traj_essemble[:,1,:].T
+            robot_samples2ped = (robot_xtrajs - closest_ped_pos[0])**2 + (robot_ytrajs - closest_ped_pos[1])**2
+            robot_samples2ped = np.min(np.sqrt(robot_samples2ped), axis=1)
+            safety_mask = (robot_samples2ped > self.close_stop_threshold).astype(float)
+            safety_samples_percent = safety_mask.mean() * 100
+            # self.get_logger().debug('percent of safe samples: {:.2f}%'.format(safety_samples_percent))
+            # self.get_logger().debug('dist 2 ped: {:.2f} m'.format(closest_dist2ped))
+
+            
+            self.close_stop_flag = False
+            if np.max(safety_mask) == 0.0:
+                safety_mask = np.ones_like(safety_mask)
+                self.close_stop_flag = True
+
+            # BRNE OPTIMIZATION HERE !!!
+            weights = brne.brne_nav(
+                xtraj_samples, ytraj_samples,
+                num_agents, self.plan_steps, self.num_samples,
+                self.cost_a1, self.cost_a2, self.cost_a3, self.ped_sample_scale,
+                self.corridor_y_min, self.corridor_y_max
+            ) 
+            # print(f"u_list_essemble: {ulist_essemble}")
+
+            # print(f"weights: {weights}")
+            if (np.mean(weights[0]) != 0):
+                weights[0] /= np.mean(weights[0])
+            
+            # print(f"weight[0]: {weights[0]}")
+            # print(f"ulist_essemble[:,:,1]: {ulist_essemble[:,:,1]}")
+            opt_cmds_1 = np.mean(ulist_essemble[:,:,0] * weights[0], axis=1)
+            opt_cmds_2 = np.mean(ulist_essemble[:,:,1] * weights[0], axis=1)
+
+            self.cmds = np.array([opt_cmds_1, opt_cmds_2]).T
+            # print(f"self.cmds: {self.cmds}")
+            # self.cmds_traj = self.cmd_tracker.sim_traj(robot_state, self.cmds)
+            self.cmds_traj = self.cmd_tracker.sim_traj(robot_state, self.cmds)
+
+
+            all_trajs_x = np.zeros((num_agents, self.plan_steps))
+            all_trajs_y = np.zeros((num_agents, self.plan_steps))
+            for i in range(num_agents):
+                all_trajs_x[i] = \
+                    np.mean(xtraj_samples[(i)*self.num_samples : (i+1)*self.num_samples] * weights[i][:,np.newaxis], axis=0)
+                all_trajs_y[i] = \
+                    np.mean(ytraj_samples[(i)*self.num_samples : (i+1)*self.num_samples] * weights[i][:,np.newaxis], axis=0)
+            # print(f"traj:\n{all_trajs_x}")
+
+            
+            wind_list, weight_array = self.wind_distribution(state, xtraj_samples, ytraj_samples, weights)
+            # print(f"weights: {weights}")
+            return all_trajs_x, all_trajs_y, opt_cmds_1, opt_cmds_2, wind_list, weight_array
+        
+        x_cmd = float(self.cmds[self.cmd_counter][0])
+        rot_cmd = float(self.cmds[self.cmd_counter][1])
+        # print(f"x, rot: {x_cmd, rot_cmd}")
+
+        self.cmd_counter += 1
+        if self.cmd_counter >= self.plan_steps:
+            self.cmd_counter = 0
+        # self.get_logger().debug(f'current control: [{cmd.linear.x}, {cmd.angular.z}]')
+        return None
+
+
+
+    def brne_rollout(self, state, traj_set_x, traj_set_y):
+
+        X = np.zeros((len(traj_set_x),self.plan_steps, 2))
+        s = state.robot_state
+        angle = np.arctan2(s.gy-s.py, s.gx-s.px)
+        v_norm = np.sqrt(s.vx**2 + s.vy**2)
+
+        for k in range(len(traj_set_x)):
+            for j in range(len(traj_set_x[0])):
+                X[k][j][0] = traj_set_x[k][j]
+                X[k][j][1] = traj_set_y[k][j]
+        
+        # print(f"X: {X}")
+
+        return X
+    
+
+
+    # uses BRNE rollout to define topological constraints for MPC
+    def local_controller(self, state):
+
+        all_trajs_x, all_trajs_y, opt_cmds_1, opt_cmds_2, wind_list, weight_array= self.brne_cb(state)
+        X = self.brne_rollout(state, all_trajs_x, all_trajs_y)
+        U = np.zeros((len(opt_cmds_1), 2))
+        U[:,0] = opt_cmds_1
+        U[:,1] = opt_cmds_2
+
+        w_vec = np.zeros(len(X)-1)
+
+        if X is not None:
+            # for j in range(1, len(X[0])):
+            for i in range(1, len(X)):
+                for j in range(1, len(X[0])):
+                    theta1 = np.arctan2(X[i][j][1] - X[0][j][1], X[i][j][0] - X[0][j][0])
+                    theta2 = np.arctan2(X[i][j-1][1] - X[0][j-1][1], X[i][j-1][0] - X[0][j-1][0])
+
+                    w_vec[i-1] += theta1-theta2
+        
+        w_vec = w_vec / (2*np.pi)
+
+
+        # print(f"BRNE wind_vec: {w_vec}")
+        # predictions = self.MPC.get_predictions(state, actions) # N x S x T' x H x 4
+        
+        self.brne_cb(state)
+        predictions = X[1:].copy()
+        ctrl = self.MPC.predict(state, wind_list, weight_array, predictions = predictions) # distribution predict
+
+        sum = (abs(ctrl[0])+ abs(ctrl[0]))
+        factor = 0.6
+        if (sum > factor) :
+            ux_norm = (ctrl[0]  / sum) * factor
+            uy_norm = (ctrl[1]  / sum) * factor
+        else:
+            ux_norm = ctrl[0]
+            uy_norm = ctrl[1]
+        
+        print(f"Ctrl: {ux_norm, uy_norm}")
+        return ActionXY(ux_norm, uy_norm)
+
+
+    # def predict(self,state):
+    def predict(self, state, border=None, radius=None, baseline=None):
+        start_time = time.time()
+        control = self.local_controller(state)
+
+        tim = time.time() - start_time
+        self.data_tracker.update_data(state,tim)
+        # print(f"Single Iterationn Runtime: {time.time() - start_time}")
+        return control

--- a/crowd_nav/policy/topology_mpc/brne_wind_cv.py
+++ b/crowd_nav/policy/topology_mpc/brne_wind_cv.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python
+
+"""Collection of examples that demonstrate the functionality of
+distributed-potential-ilqr in various scenarios.
+
+Including:
+ - single unicycle
+ - single quadcopter (6D)
+ - two quads with one human
+ - random multi-agent simulation
+
+"""
+
+import rvo2
+from crowd_sim.envs.utils.action import ActionXY, ActionRot
+
+import numpy as np
+import matplotlib.pyplot as plt
+from crowd_sim.envs.policy.policy import Policy
+from crowd_nav.policy.vecMPC.controller_wind import vecMPC
+
+from crowd_nav.policy.brne import brne as brne
+
+import logging
+import math
+from crowd_nav.policy.brne.traj_tracker import TrajTracker
+import copy
+import time
+
+# import dpilqr
+# import scenarios
+
+π = np.pi
+g = 9.80665
+
+
+class BRNEWINDCV(Policy):
+
+    def __init__(self,config):
+        super().__init__()
+        self.name = 'brne_wind'
+        self.trainable = False
+        self.U = None
+        self.MPC = vecMPC(config)
+        self.kinematics = 'holonomic'
+        self.multiagent_training = False
+        self.sim = None
+        self.plan_steps = 5
+        self.num_samples = 4
+        self.a1 = 10
+        self.a2 = 10
+        self.a3 = 10
+        self.brne_activate_threshold = 12
+        self.dt = 0.25
+        self.nominal_vel = 1.0
+        self.max_lin_vel = 1.0
+        self.max_ang_vel = 0.3
+        self.close_stop_threshold = 0.5
+        self.cost_a1 = 2.0
+        self.cost_a2 = 7.0
+        self.cost_a3 = 5.0
+        self.ped_sample_scale = 0.1
+        self.corridor_y_min = -12.0
+        self.corridor_y_max = 12.0
+        self.cmd_tracker = TrajTracker(dt=self.dt, max_lin_vel=self.max_lin_vel, max_ang_vel=self.max_ang_vel)   # the class that converts way points to control commands
+        self.robot_goal = None
+        self.cmd_counter = 0
+        self.open_space_velocity = 0.6
+        self.num_agents = 13 # maximum number of agents considered
+        tlist = np.arange(self.plan_steps) * self.dt
+        train_ts = np.array([tlist[0]])
+        train_noise = np.array([1e-04])
+        test_ts = tlist
+        self.kernel_a1 = 0.2
+        self.kernel_a2 = 0.2
+        self.cov_Lmat, self.cov_mat = brne.get_Lmat_nb(train_ts, test_ts, train_noise, self.kernel_a1, self.kernel_a2)
+
+
+
+
+    def configure(self, config):
+        assert True
+
+
+    def brne_cb(self, state):
+        self_state = state.robot_state
+        self.robot_goal = np.array([self_state.gx, self_state.gy])
+
+        # BEGIN BRNE
+        ped_info_list = []
+        dists2peds = []
+
+        # we go through each perceived pedestrian and save the information
+        for ped in state.human_states:
+            dist2ped = np.sqrt((self_state.px-ped.px)**2 + (self_state.py-ped.py)**2)
+            if dist2ped < self.brne_activate_threshold:  # only consider pedestrians within the activate threshold
+                ped_info = np.array([
+                    ped.px, ped.py, ped.vx, ped.vy
+                ])
+                ped_info_list.append(ped_info)
+
+                dists2peds.append(dist2ped)
+
+        ped_info_list = np.array(ped_info_list)
+        self.num_peds = len(ped_info_list)
+
+        dists2peds = np.array(dists2peds)
+
+        # compute how many pedestrians we are actually interacting with
+        num_agents = np.minimum(self.num_peds+1, self.num_agents)
+
+        print(f"CMD COUNTER: {self.cmd_counter}")
+
+
+
+        if self.cmd_counter == 0 and num_agents > 1:
+            # print("peds")
+
+            ped_indices = np.argsort(dists2peds)[:num_agents-1]  # we only pick the N closest pedestrian to interact with
+            robot_state = np.array([self_state.px,self_state.py,self_state.theta])
+
+            x_pts = brne.mvn_sample_normal((num_agents-1) * self.num_samples, self.plan_steps, self.cov_Lmat)
+            y_pts = brne.mvn_sample_normal((num_agents-1) * self.num_samples, self.plan_steps, self.cov_Lmat)
+
+            # self.get_logger().info(f'X and y pts shape {x_pts.shape} {y_pts.shape}')
+            # ctrl space configuration here
+            xtraj_samples = np.zeros((
+                num_agents * self.num_samples, self.plan_steps
+            ))
+            ytraj_samples = np.zeros((
+                num_agents * self.num_samples, self.plan_steps
+            ))
+
+            closest_dist2ped = 100.0
+            closest_ped_pos = np.zeros(2) + 100.0
+            for i, ped_id in enumerate(ped_indices):
+                ped_pos = ped_info_list[ped_id][:2]
+                ped_vel = ped_info_list[ped_id][2:]
+                speed_factor = np.linalg.norm(ped_vel)
+                ped_xmean = ped_pos[0] + np.arange(self.plan_steps) * self.dt * ped_vel[0]
+                ped_ymean = ped_pos[1] + np.arange(self.plan_steps) * self.dt * ped_vel[1]
+
+
+                xtraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] = \
+                    x_pts[i*self.num_samples : (i+1)*self.num_samples] * speed_factor + ped_xmean
+                ytraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] = \
+                    y_pts[i*self.num_samples : (i+1)*self.num_samples] * speed_factor + ped_ymean
+                
+                dist2ped = np.linalg.norm([
+                    robot_state[:2] - ped_pos[:2] # questionable translation from ros
+                ])
+                if dist2ped < closest_dist2ped:
+                    closest_dist2ped = dist2ped
+                    closest_ped_pos = ped_pos.copy()
+
+
+            st = copy.copy(robot_state)
+
+            # if self.robot_goal is None:
+            #     goal = np.array([6.0, 0.0])
+            # else:
+            #     goal = self.robot_goal[:2]
+
+            goal = np.array([self_state.gx, self_state.gy])
+            # logging.info("goal: {}".format(goal))
+
+            angle = st[2]
+            if angle > 0.0:
+                theta_a = angle - np.pi/2
+            else:
+                theta_a = angle + np.pi/2
+            axis_vec = np.array([
+                np.cos(theta_a), np.sin(theta_a)
+            ])  
+            # # TODO: Check theta frame/range with print statements
+            # axis_vec = np.array([
+            #     np.cos(angle), np.sin(angle)
+            # ])
+            vec2goal = np.array([goal[0] - st[0], goal[1] - st[1]])
+            # logging.info("vec2goal: {}".format(vec2goal))
+            dist2goal = np.linalg.norm(vec2goal)
+            proj_len = (axis_vec @ vec2goal) / (vec2goal @ vec2goal) * dist2goal
+            # proj_len = (np.dot(axis_vec, vec2goal)) / (np.dot(vec2goal, vec2goal)) * dist2goal
+            # logging.info("proj_len: {}".format(proj_len))
+            # if (proj_len == 0):
+            #     proj_len = 0.001
+            radius = 0.5 * dist2goal / proj_len 
+            # print(proj_len)
+
+            # print(f"radius: {radius}")
+            if angle > 0.0:
+                ut = np.array([self.nominal_vel, -self.nominal_vel/radius])
+            else:
+                ut = np.array([self.nominal_vel, self.nominal_vel/radius])
+            nominal_cmds = np.tile(ut, reps=(self.plan_steps,1))
+            # self.get_logger().info(f"Nominal commands {nominal_cmds.shape}\n{nominal_cmds}")
+            ulist_essemble = brne.get_ulist_essemble(
+                nominal_cmds, self.max_lin_vel, self.max_ang_vel, self.num_samples
+            )
+
+            # self.get_logger().info(f"ulist {ulist_essemble.shape}\n{ulist_essemble}")
+            # print(f"essemble {ulist_essemble}")
+            tiles = np.tile(robot_state, reps=(self.num_samples,1)).T
+
+            traj_essemble = brne.traj_sim_essemble( 
+                tiles,
+                ulist_essemble,
+                self.dt
+            )
+
+            # print(traj_essemble)
+            # logging.info("essemble: {}".format(traj_essemble))
+
+            xtraj_samples[0:self.num_samples] = traj_essemble[:,0,:].T
+            ytraj_samples[0:self.num_samples] = traj_essemble[:,1,:].T
+
+            # generate sample weight mask for the closest pedestrian
+            robot_xtrajs = traj_essemble[:,0,:].T
+            robot_ytrajs = traj_essemble[:,1,:].T
+            robot_samples2ped = (robot_xtrajs - closest_ped_pos[0])**2 + (robot_ytrajs - closest_ped_pos[1])**2
+            robot_samples2ped = np.min(np.sqrt(robot_samples2ped), axis=1)
+            safety_mask = (robot_samples2ped > self.close_stop_threshold).astype(float)
+            safety_samples_percent = safety_mask.mean() * 100
+            # self.get_logger().debug('dist 2 ped: {:.2f} m'.format(closest_dist2ped))
+            
+            self.close_stop_flag = False
+            if np.max(safety_mask) == 0.0:
+                safety_mask = np.ones_like(safety_mask)
+                self.close_stop_flag = True
+            # self.get_logger().debug('safety mask: {}'.format(safety_mask))
+
+            # BRNE OPTIMIZATION HERE !!!
+            weights = brne.brne_nav(
+                xtraj_samples, ytraj_samples,
+                num_agents, self.plan_steps, self.num_samples,
+                self.cost_a1, self.cost_a2, self.cost_a3, self.ped_sample_scale,
+                self.corridor_y_min, self.corridor_y_max
+            ) 
+
+            # print(f"weights: {weights}")
+            if (np.mean(weights[0]) != 0):
+                weights[0] /= np.mean(weights[0])
+            
+            opt_cmds_1 = np.mean(ulist_essemble[:,:,0] * weights[0], axis=1)
+            opt_cmds_2 = np.mean(ulist_essemble[:,:,1] * weights[0], axis=1)
+
+            self.cmds = np.array([opt_cmds_1, opt_cmds_2]).T
+            # print(f"self.cmds: {self.cmds}")
+            self.cmds_traj = self.cmd_tracker.sim_traj(robot_state, self.cmds)
+
+
+            ped_trajs_x = np.zeros((num_agents-1, self.plan_steps))
+            ped_trajs_y = np.zeros((num_agents-1, self.plan_steps))
+            for i in range(num_agents-1):
+                ped_trajs_x[i] = \
+                    np.mean(xtraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] * weights[i+1][:,np.newaxis], axis=0)
+                ped_trajs_y[i] = \
+                    np.mean(ytraj_samples[(i+1)*self.num_samples : (i+2)*self.num_samples] * weights[i+1][:,np.newaxis], axis=0)
+            traj = self.cmd_tracker.sim_traj(robot_state, self.cmds)
+            return traj
+        
+        x_cmd = float(self.cmds[self.cmd_counter][0])
+        rot_cmd = float(self.cmds[self.cmd_counter][1])
+
+        self.cmd_counter += 1
+        if self.cmd_counter >= self.plan_steps:
+            self.cmd_counter = 0
+        # self.get_logger().debug(f'current control: [{cmd.linear.x}, {cmd.angular.z}]')
+        return None
+
+
+
+    # rollout robot trajectory with BNRE, rollout constant velocity pedestrian trajectory 
+    def brne_cv_rollout(self, state):
+
+        rob_traj = self.brne_cb(state)
+        X = np.zeros((len(rob_traj),len(state.human_states)+1, 2))
+        s = state.robot_state
+        angle = np.arctan2(s.gy-s.py, s.gx-s.px)
+        v_norm = np.sqrt(s.vx**2 + s.vy**2)
+
+        for k in range(len(rob_traj)):
+            X[k][0][0] = rob_traj[k][0]
+            X[k][0][1] = rob_traj[k][1]
+        
+
+        for k in range(len(rob_traj)):
+            for i, s in enumerate(state.human_states):
+                X[k][i+1][0] = s.px + s.vx * k * 0.25 # TODO: make this not harcoded
+                X[k][i+1][1] = s.py + s.vy * k * 0.25
+
+        return X
+    
+
+    # 
+    def local_controller(self, state):
+        X = self.brne_cv_rollout(state)
+        w_vec = np.zeros(len(state.human_states))
+
+        # print(len(X[0])/3)
+        if X is not None:
+            for i in range(1, len(X[0])):
+                theta_end = np.arctan2(X[1][i][1] - X[1][0][1], X[1][i][0] - X[1][0][0])
+                theta_start = np.arctan2(X[0][i][1] - X[0][0][1], X[0][i][0] - X[0][0][0])
+                w = (theta_end - theta_start)/(2*np.pi)
+                w_vec[i-1] = w
+
+        print(f"BRNE (cv ped) wind_vec: {w_vec}")
+        # predictions = self.MPC.get_predictions(state, actions) # N x S x T' x H x 4
+        self.brne_cb(state)
+        ctrl = self.MPC.predict(state, w_vec)
+        # print(f"sza!: {ctrl}")
+        sum = (abs(ctrl[0])+ abs(ctrl[0]))
+        factor = 0.6
+        if (sum > factor) :
+            ux_norm = (ctrl[0]  / sum) * factor
+            uy_norm = (ctrl[1]  / sum) * factor
+        else:
+            ux_norm = ctrl[0]
+            uy_norm = ctrl[1]
+
+        return ActionXY(ux_norm, uy_norm)
+
+    # def predict(self,state):
+    def predict(self, state, border=None, radius=None, baseline=None):
+        start_time = time.time()
+        control = self.local_controller(state)
+        print(f"Single Iterationn Runtime: {time.time() - start_time}")
+        return control

--- a/crowd_nav/policy/topology_mpc/cv_wind.py
+++ b/crowd_nav/policy/topology_mpc/cv_wind.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+"""Collection of examples that demonstrate the functionality of
+distributed-potential-ilqr in various scenarios.
+
+Including:
+ - single unicycle
+ - single quadcopter (6D)
+ - two quads with one human
+ - random multi-agent simulation
+
+"""
+
+import rvo2
+from crowd_sim.envs.utils.action import ActionXY, ActionRot
+
+import numpy as np
+import matplotlib.pyplot as plt
+from crowd_sim.envs.policy.policy import Policy
+from crowd_nav.policy.vecMPC.controller_wind import vecMPC
+
+import time
+
+# import dpilqr
+# import scenarios
+
+π = np.pi
+g = 9.80665
+
+
+class CVWIND(Policy):
+
+    def __init__(self,config):
+        super().__init__()
+        self.name = 'cv_wind'
+        self.trainable = False
+        self.kinematics = 'holonomic'
+        self.multiagent_training = False
+        self.sim = None
+        self.U = None
+        self.MPC = vecMPC(config)
+  
+
+    def cv_rollout(self, state):
+        X = np.zeros((2,len(state.human_states)+1, 2))
+        s = state.robot_state
+        angle = np.arctan2(s.gy-s.py, s.gx-s.px)
+        v_norm = np.sqrt(s.vx**2 + s.vy**2)
+
+        X[0][0][0] = s.px
+        X[0][0][1] = s.py
+        X[1][0][0] = s.px + v_norm * np.cos(angle) * 7 * 0.25 
+        X[1][0][1] = s.py + v_norm * np.sin(angle) * 7 * 0.25 
+
+        for i, s in enumerate(state.human_states):
+            X[0][i+1][0] = s.px
+            X[0][i+1][1] = s.py
+            X[1][i+1][0] = s.px + s.vx * 7 * 0.25 # TODO: make this not harcoded
+            X[1][i+1][1] = s.py + s.vy * 7 * 0.25
+
+        return X
+    
+
+
+    # uses constant velocity rollout to define topological constraints for MPC
+    def local_controller(self, state):
+        X = self.cv_rollout(state)
+        w_vec = np.zeros(len(state.human_states))
+
+        # print(len(X[0])/3)
+        for i in range(1, len(X[0])):
+            theta_end = np.arctan2(X[1][i][1] - X[1][0][1], X[1][i][0] - X[1][0][0])
+            theta_start = np.arctan2(X[0][i][1] - X[0][0][1], X[0][i][0] - X[0][0][0])
+            w = (theta_end - theta_start)/(2*np.pi)
+            w_vec[i-1] = w
+
+        print(f"CV wind_vec: {w_vec}")
+        # predictions = self.MPC.get_predictions(state, actions) # N x S x T' x H x 4
+
+        ctrl = self.MPC.predict(state, w_vec)
+        print(f"sza!: {ctrl}")
+        sum = (abs(ctrl[0])+ abs(ctrl[0]))
+        factor = 0.6
+        if (sum > factor) :
+            ux_norm = (ctrl[0]  / sum) * factor
+            uy_norm = (ctrl[1]  / sum) * factor
+        else:
+            ux_norm = ctrl[0]
+            uy_norm = ctrl[1]
+
+        return ActionXY(ux_norm, uy_norm)
+
+    def predict(self, state, border=None, radius=None, baseline=None):
+        start_time = time.time()
+        control = self.local_controller(state)
+        print(f"Single Iterationn Runtime: {time.time() - start_time}")
+        return control

--- a/crowd_sim/README.md
+++ b/crowd_sim/README.md
@@ -1,10 +1,3 @@
-# Training and Tuning
-## MPC and MPPI
-The MPC and MPPI method cost function parameters are tuned via a grid search over the sigma h, s, and r parameters in the range [0.3, 2.1] in intervals of 0.3. The q parameters were fixed manually to (100.0, 1.0, 5.0, 1.0) and kept constant across methods. The additional MPPI parameters (noise covariance diagonal, samples, and horizon) were also tuned using a separate grid search with values (1.0, 2.0, 3.0, 4.0, 5.0), (100, 250, 500, 1000), (3, 4, 5, 6, 7), rejecting combinations that led to a control loop operating slower than 0.25Hz (the simulation timestep). All parameters were tuned in a passing and crossing scenario with 5 ORCA and 5 SFM agents in a 10x10m workspace using 100 trials to calculate metrics.
-
-## RGL
-RGL training was attempted in scenarios with (5, 10, 15) (ORCA, SFM, ORCA and SFM) agents in a 12x12m workspace with circle crossing directionality. We found the training did not converge to a generalized collision avoiding policy in all cases except for the 5 agent ORCA scenario, so that is the model used in experiments.
-
 # Simulation Framework
 ## Environment
 The environment contains n+1 agents. N of them are humans controlled by certain unknown
@@ -44,8 +37,18 @@ the knowledge of environments is defined as JointState, and it's different from 
 * DualState: concatenation of one agent's full state and one another agent's observable state
 * JoinState: concatenation of one agent's full state and all other agents' observable states 
 
-
 ## Action
 There are two types of actions depending on what kinematics constraint the agent has.
 * ActionXY: (vx, vy) if kinematics == 'holonomic'
 * ActionRot: (velocity, rotation angle) if kinematics == 'unicycle'
+
+## Groups
+This branch adds the ability to compute and visualize pedestrian groups and their occupied space. Currently, there are two metods implemented for generating groups:
+* DBScan
+* Coherent Filter
+
+And two methods for generating group space:
+* Convex Hull
+* Perimeter Polygon
+
+For more information on each of these methods, see **crowd_sim/envs/grouping/README.md**.

--- a/crowd_sim/envs/grouping/README.md
+++ b/crowd_sim/envs/grouping/README.md
@@ -1,0 +1,48 @@
+# Code overview
+The file **grouping_functions.py** contains two classes:
+* Grouper: clutsers and colors pedestrians for visualization. 
+* GroupSpaceGenerator: contains methods for computing the perimeter points for visualizing the occupying space of clustered groups.
+
+Within **crowd_sim/envs/crowd_sim.py**, the Grouper object is called during the 'update' function. The group space is visualized on a separate plot from the main environment, and separate 'update' functions are used for each space generation method, which can be specified at the bottom of the file. 
+
+## Grouper
+The grouper class stores the states, humans, groups, and group colors for the complete simulation iteration. Within this class, there are two methods for clustering pedestrians. 
+
+**DBScan:** inspired by the work by [Wang et. al.](https://chrismavrogiannis.com/pdfs/wang2021groupbased.pdf), we employ DBScan (*sklearn* toolkit) to group pedestrians based on their position and velocity.
+
+**Coherent Filter:** we adapt the work by [Zhou et al.](https://scispace.com/pdf/coherent-filtering-detecting-coherent-motions-from-crowd-xi8nhnf2s2.pdf), which considers the spatiotemporal relationship of pedestrians across frames to detect coherent motions. The implementation is based principles of *Coherent Neighbor Invariance*, that the neighborship of coherent motions tend to remain invariant over time, and the velocity correlations of neighboring individuals remain high over time.
+
+## GroupSpaceGenerator
+Within this class, there are two methods for computing the group space. Note: these implementations have been developed using the **Coherent Filter** grouping approach, and currently see less consistent results with DBScan (although this is likely a matter of tuning parameters).
+
+**Convex Hull (social space):** We first compute personal space for each pedestrian based on the work of [Rachel Kirby](https://www.ri.cmu.edu/publications/social-robot-navigation/), then use the *scipy* toolbox to generate a convex hull containing all members of the group (including personal space).
+
+**Perimeter Polygon:** We find the outermost members of each group and use their poses to generate a polygon encapsulating the remaining group members. Simple circles are used to generate personal space.
+
+## Setup
+Used Python 3.8.5 for development.
+
+## Getting started
+To select the methods for grouping and space generation, see inline comments in the code. 
+
+Within **crowd_sim/envs/crowd_sim.py**, there are two major modifications to the original *ComplexityNav* **crowd_sim.py**. Use 
+```
+self.group_labels = self.dbscan_group(frame) 
+```
+for dbscan clustering, and 
+```
+self.group_labels = self.CoherentFilter(frame, 5, 3, 0.9)
+```
+for coherent filter. Use 
+
+```
+self.group_labels = self.dbscan_group(frame) 
+```
+update_chull(0)
+anim2 = animation.FuncAnimation(fig2, update_chull, frames=len(self.states), interval=self.time_step * 1000)
+'''
+for the convex hull space generator, and 
+update_complete_polygon(0)
+anim2 = animation.FuncAnimation(fig2, update_complete_polygon, frames=len(self.states), interval=self.time_step * 1000)
+'''
+for the polynomial method.

--- a/crowd_sim/envs/grouping/grouping_functions.py
+++ b/crowd_sim/envs/grouping/grouping_functions.py
@@ -1,0 +1,537 @@
+import numpy as np
+
+from sklearn.cluster import DBSCAN
+from sklearn.cluster import HDBSCAN
+from scipy.spatial import Voronoi
+from scipy.spatial import ConvexHull
+from shapely.geometry import Polygon
+from tqdm import tqdm
+from itertools import combinations
+import random
+from numpy.linalg import norm
+
+
+
+
+class Grouper():
+
+    def __init__(self):
+        self.humans = None
+        self.states = None
+
+        # for grouping
+        self.group_colors = ['black']
+        self.group_labels = [0]
+
+    def _DBScan_grouping(self, labels, properties, standard):
+            '''
+            DBSCAN clustering using the sklearn toolbox
+            Inputs:
+                labels: the input labels. This will be destructively updated to
+                        reflect the group memberships after DBSCAN.
+                properties: the input that clustering is based on.
+                            Could be positions, velocities or orientation.
+                standard: the threshold value for clustering.
+
+            Credit: Wang et al. (https://proceedings.mlr.press/v164/wang22e.html)
+            '''
+
+            max_lb = max(labels)
+            for lb in range(max_lb + 1):
+                sub_properties = []
+                sub_idxes = []
+                # Only perform DBSCAN within groups (i.e. have the same membership id)
+                for i in range(len(labels)):
+                    if labels[i] == lb:
+                        sub_properties.append(properties[i])
+                        sub_idxes.append(i)
+        
+                # If there's only 1 person then no need to further group
+                if len(sub_idxes) > 1:
+                    db = DBSCAN(eps = standard, min_samples = 1)
+                    sub_labels = db.fit_predict(sub_properties)
+                    max_label = max(labels)
+
+
+                    # db.fit_predict always return labels starting from index 0
+                    # we can add these to the current biggest id number to create
+                    # new group ids.
+                    for i, sub_lb in enumerate(sub_labels):
+                        if sub_lb > 0:
+                            labels[sub_idxes[i]] = max_label + sub_lb
+            return labels
+
+
+    def _HDBScan_grouping(self, labels, properties, standard):
+            '''
+            HDBSCAN clustering using the sklearn toolbox
+            Inputs:
+                labels: the input labels. This will be destructively updated to
+                        reflect the group memberships after DBSCAN.
+                properties: the input that clustering is based on.
+                            Could be positions, velocities or orientation.
+                standard: the threshold value for clustering.
+
+            Credit: Wang et al. (https://proceedings.mlr.press/v164/wang22e.html)
+            '''
+
+
+            max_lb = max(labels)
+            for lb in range(max_lb + 1):
+                sub_properties = []
+                sub_idxes = []
+                # Only perform DBSCAN within groups (i.e. have the same membership id)
+                for i in range(len(labels)):
+                    if labels[i] == lb:
+                        sub_properties.append(properties[i])
+                        sub_idxes.append(i)
+            
+                # If there's only 1 person then no need to further group
+                if len(sub_idxes) > 1:
+                    hdb = HDBSCAN(min_cluster_size = 2)
+                    sub_labels = hdb.fit_predict(sub_properties)
+                    max_label = max(labels)
+
+
+                    # db.fit_predict always return labels starting from index 0
+                    # we can add these to the current biggest id number to create
+                    # new group ids.
+                    for i, sub_lb in enumerate(sub_labels):
+                        if sub_lb > 0:
+                            labels[sub_idxes[i]] = max_label + sub_lb
+            return labels
+
+
+
+    def dbscan_group(self, frame):
+            # if params == None:
+            pos = 1
+            ori = 10
+            vel = 1.0
+
+            params = {'position_threshold': pos,
+                        'orientation_threshold': ori / 180.0 * np.pi,
+                        'velocity_threshold': vel,
+                        'velocity_ignore_threshold': 0.5}
+
+
+            num_people = len(self.humans)
+            vel_orientation_array = []
+            vel_magnitude_array = []
+            position_array = []
+            humans_at_frame = [self.states[frame][1][j] for j in range(len(self.humans))]
+
+            # logging.info("Group at frame: {}".format(frame))
+            for h in humans_at_frame:
+                vx = h.vx
+                vy = h.vy
+                velocity_magnitude = np.sqrt(vx ** 2 + vy ** 2)
+                position_array.append((h.px,h.py))
+                if velocity_magnitude < params['velocity_ignore_threshold']:
+                    # if too slow, then treated as being stationary
+                    vel_orientation_array.append((0.0, 0.0))
+                    vel_magnitude_array.append((0.0, 0.0))
+                else:
+                    vel_orientation_array.append((vx / velocity_magnitude, vy / velocity_magnitude))
+                    vel_magnitude_array.append((0.0, velocity_magnitude)) # Add 0 to fool DBSCAN
+            # grouping in current frame (three passes, each on different criteria)
+            labels = [0] * num_people
+            labels = self._DBScan_grouping(labels, vel_orientation_array,
+                                        params['orientation_threshold'])
+            labels = self._DBScan_grouping(labels, vel_magnitude_array,
+                                        params['velocity_threshold'])
+            labels = self._DBScan_grouping(labels, position_array,
+                                    params['position_threshold'])
+        
+            # labels = self._HDBScan_grouping(labels, vel_orientation_array,
+            #                             params['orientation_threshold'])
+            # labels = self._HDBScan_grouping(labels, vel_magnitude_array,
+            #                             params['velocity_threshold'])
+            # labels = self._HDBScan_grouping(labels, position_array,
+            #                             params['position_threshold'])
+            return labels
+
+    
+    def pair2cluster(self, pairwiseData,totalNum):
+
+        clusterNum = 0
+        clusterIndexList = [0] * totalNum
+
+        for i in range(len(pairwiseData)):
+            curPair = pairwiseData[i]
+            curPairAlabel = clusterIndexList[curPair[0]]
+            curPairBlabel = clusterIndexList[curPair[1]]
+
+            if curPairAlabel == 0 and curPairBlabel == 0:
+                clusterNum = clusterNum + 1
+                curPairLabel = clusterNum
+                clusterIndexList[curPair[0]] = curPairLabel
+                clusterIndexList[curPair[1]] = curPairLabel
+            elif curPairAlabel != 0 and curPairBlabel == 0:
+                clusterIndexList[curPair[1]] = curPairAlabel
+            elif curPairBlabel != 0 and curPairAlabel == 0:
+                clusterIndexList[curPair[0]] = curPairBlabel
+            else:
+                combineLabel = min(curPairAlabel,curPairBlabel)
+                for j in range(len(clusterIndexList)):
+                    if clusterIndexList[j] == curPairAlabel or clusterIndexList[j] == curPairBlabel:
+                        clusterIndexList[j] = combineLabel
+        return clusterIndexList
+
+
+
+    def CF_neighbor2pair(self, neighborSet,correlationSet,d):
+        zero_neighbor_set = neighborSet[1]
+        n_point = zero_neighbor_set.shape[0]
+
+        pair_set = []
+        corre_set = []
+
+        for i in range(n_point):
+            cur_intersect = zero_neighbor_set[i]
+            cur_corre = [0] * len(zero_neighbor_set[0])
+            for j in range(1,d):
+                next_neighbor_set = neighborSet[j][i]
+                next_corre_set = correlationSet[j][i]
+                cur_intersect, cur_indexes, next_indexes = np.intersect1d(cur_intersect, next_neighbor_set, return_indices=True)
+                tempList = []
+                for k in range(len(cur_indexes)):
+                    tempList.append(cur_corre[cur_indexes[k]] + next_corre_set[next_indexes[k]]) 
+                cur_corre = tempList
+            if cur_intersect.size > 0:
+                for k in range(len(cur_corre)):
+                    corre_set.append(cur_corre[k])
+                for k in range(len(cur_intersect)):
+                    pair_set.append([i, cur_intersect[k]])
+
+        return pair_set, corre_set
+
+
+        
+
+    def CF_neighbor(self, allXset, allVset, K, id_set = None):
+        d = len(allXset)
+        n_point = len(allXset[0])
+        neighbor_set = [None] * d
+        correlation_set = [None] * d
+
+        angle_threshold = 45
+
+        for j in range(d):
+            cur_allX = allXset[j]
+            cur_allV = allVset[j]
+            cur_neighbor_graph = np.zeros((n_point, K), dtype=int)
+            cur_correlation_graph = np.zeros((n_point, K))
+
+            for i in range(n_point):
+                cur_X = cur_allX[i]
+                diff = np.tile(cur_X, [n_point, 1]) - cur_allX
+                distance = [[x, 0] for x in range(n_point)]
+                for k, (x,y) in enumerate(diff):
+                    distance[k][1] = np.sqrt(x**2 + y**2)
+
+                distance = sorted(distance, key=lambda x: x[1])  
+
+                kNN = 0
+                ind = 0
+                while kNN < K and ind < len(distance):
+                    if cur_allV[distance[kNN+1][0]][0] != 0 and (np.arctan(cur_allV[distance[kNN+1][0]][1]/cur_allV[distance[kNN+1][0]][0]) * np.pi/180) < angle_threshold:
+                        if norm(cur_allV[i]) > 0 and norm(cur_allV[distance[kNN + 1][0]]) > 0:
+                            coefficient = np.dot(cur_allV[i], cur_allV[distance[kNN + 1][0]])
+                            coefficient /= (norm(cur_allV[i]) * norm(cur_allV[distance[kNN + 1][0]]))
+                            cur_neighbor_graph[i][kNN] = distance[kNN + 1][0]
+                            cur_correlation_graph[i][kNN] = coefficient
+                            kNN += 1
+                    ind += 1
+                    kNN += 1
+            
+            neighbor_set[j] = cur_neighbor_graph
+            correlation_set[j] = cur_correlation_graph
+
+        return neighbor_set, correlation_set
+
+
+    def getPosVel(self, frame, numFrames):
+        
+        
+        firstFrame = max(0,frame - numFrames)
+        
+        sz = 0
+        for i in range(firstFrame, frame):
+            if sz < len(self.states[i][1]):
+                sz = len(self.states[i][1]) 
+
+        positions = np.empty((frame-firstFrame,sz,2),np.float64)
+        velocities = np.empty((frame-firstFrame,sz,2),np.float64)
+
+        for i in range(firstFrame, frame):
+            humans_at_frame = [self.states[i][1][j] for j in range(len(self.humans))]
+            for j,h in enumerate(humans_at_frame):
+                positions[i - firstFrame][j][0]= h.px
+                positions[i - firstFrame][j][1] = h.py
+
+                velocities[i - firstFrame][j][0] = h.vx
+                velocities[i - firstFrame][j][1] = h.vy
+
+
+        return positions, velocities
+
+
+
+    def CoherentFilter(self, frame, numFrames, K, lamda):
+        '''
+        Adapted from Algorithm 1 of "Coherent Filtering: Detecting coherent motion patterns at each frame"
+        by Zhou et al. (https://scispace.com/pdf/coherent-filtering-detecting-coherent-motions-from-crowd-xi8nhnf2s2.pdf)
+        '''
+
+        ## step1: find K nearest neighbor set at each time
+        positions, velocities = self.getPosVel(frame, numFrames) # For ORCA
+
+        numFrames = min(frame, numFrames)
+        firstPos = positions[0]
+        nPoint = len(firstPos)
+
+
+        neighborSet, correlationSet = self.CF_neighbor(positions,velocities,K)
+
+
+        ## step2: find the invariant neighbor and pairwise connection set
+        [pairSet,correSet] = self.CF_neighbor2pair(neighborSet,correlationSet,numFrames)
+
+
+        ## step3: threshold pairwise connection set by the averaged correlation values, then generate cluster components 
+        pairIndex = [] # included pairwise connection
+        for i in range(len(correSet)):
+            if correSet[i] > lamda:
+                pairIndex.append(i)
+        
+        filteredPairs = [pairSet[i] for i in pairIndex]
+        # 
+
+        
+        clusterIndex = self.pair2cluster(filteredPairs,nPoint)
+
+
+        return clusterIndex
+
+
+
+    
+    def group_color(self, frame):
+        '''
+        Generates social groups of pedestrians using either DBScan or CoherentFilter (see comment below). 
+        
+        '''
+
+        if frame <= 3:
+            return ['b'] * 100
+        
+        ###############################################################
+        ## switch between coherent filter and dbscan. 
+        ## Note: only coherent filter requires the above frame buffer.
+
+        # self.group_labels = self.dbscan_group(frame) 
+        self.group_labels = self.CoherentFilter(frame, 5, 3, 0.9)
+
+        ###############################################################
+
+
+        def get_colors(n):
+            colors = []
+            for i in range(n):
+                new_c = "#%06x" % random.randint(0, 0xFFFFFF)
+                for c in self.group_colors:
+                    while (np.abs(c - new_c) < 0xFFFFF0):
+                        new_c = "#%06x" % random.randint(0, 0xFFFFFF)
+                colors.append(new_c)
+            return colors
+        
+        
+        get_colors = lambda n: ["#%06x" % random.randint(0, 0xFFFFFF) for _ in range(n)]
+        num_groups = max(self.group_labels) + 1
+
+        if num_groups > len(self.group_colors):
+            self.group_colors = self.group_colors + get_colors(num_groups - len(self.group_colors))
+
+        group_membership_color = [0] * len(self.group_labels)
+
+        for i in range(len(self.group_labels)):
+           group_membership_color[i] = self.group_colors[self.group_labels[i]]
+        return group_membership_color
+
+
+class GroupSpaceGenerator():
+    def __init__(self):
+        pass
+
+    def boundary_dist(self, velocity, rel_ang, const=0.354163):
+        # Parameters from Rachel Kirby's thesis
+        front_coeff = 1.0
+        side_coeff = 2.0 / 3.0
+        rear_coeff = 0.5
+        safety_dist = 0.5
+        velocity_x = velocity[0]
+        velocity_y = velocity[1]
+
+        velocity_magnitude = np.sqrt(velocity_x ** 2 + velocity_y ** 2)
+        variance_front = max(0.5, front_coeff * velocity_magnitude)
+        variance_side = side_coeff * variance_front
+        variance_rear = rear_coeff * variance_front
+
+        rel_ang = rel_ang % (2 * np.pi)
+        flag = int(np.floor(rel_ang / (np.pi / 2)))
+        if flag == 0:
+            prev_variance = variance_front
+            next_variance = variance_side
+        elif flag == 1:
+            prev_variance = variance_rear
+            next_variance = variance_side
+        elif flag == 2:
+            prev_variance = variance_rear
+            next_variance = variance_side
+        else:
+            prev_variance = variance_front
+            next_variance = variance_side
+
+        dist = np.sqrt(const / ((np.cos(rel_ang) ** 2 / (2 * prev_variance)) + (np.sin(rel_ang) ** 2 / (2 * next_variance))))
+        dist = max(safety_dist, dist)
+
+
+        return dist
+
+    def draw_social_shapes(self, position, velocity, const=0.35):
+        '''
+        draws social group shapes given the positions and velocities of the pedestrians, 
+        with social considerations based on the work by Rachel Kirby (https://www.ri.cmu.edu/publications/social-robot-navigation/)
+
+        returns the vertices of the convex hull
+        '''
+
+        total_increments = 10 # controls the resolution of the blobs
+        quater_increments = total_increments / 4
+        angle_increment = 2 * np.pi / total_increments
+
+        # Draw a personal space for each pedestrian within the group
+        contour_points = []
+        for i in range(len(position)):
+            center_x = position[i][0]
+            center_y = position[i][1]
+            velocity_x = velocity[i][0]
+            velocity_y = velocity[i][1]
+            velocity_angle = np.arctan2(velocity_y, velocity_x)
+
+            # Draw four quater-ovals with the axis determined by front, side and rear "variances"
+            # The overall shape contour does not have discontinuities.
+            for j in range(total_increments):
+
+                rel_ang = angle_increment * j
+                value = self.boundary_dist(velocity[i], rel_ang, const)
+                addition_angle = velocity_angle + rel_ang
+                x = center_x + np.cos(addition_angle) * value
+                y = center_y + np.sin(addition_angle) * value
+                contour_points.append([x, y])
+
+        # Get the convex hull of all the personal spaces
+        convex_hull_vertices = []
+        hull = ConvexHull(np.array(contour_points))
+        for i in hull.vertices:
+            hull_vertice = [contour_points[i][0], contour_points[i][1]]
+            convex_hull_vertices.append(hull_vertice)
+
+        return convex_hull_vertices
+
+
+
+    def trace_polygon(self, groups, group_positions, g_index):
+        '''
+        Finds and returns the perimeter of the specified group (g_index). 
+        Excess information passed as parameters for simplicity, could certainly be optimized.
+        '''
+
+        threshold = 1
+
+        def find_right_side(g_ind):
+            side = [] # bottom to top
+            g_indices_w_y = [] # indices of individuals in the GROUPS OBJECT, so not the ind of the agent, but the ind of the ind of the agent in the group
+            for i in range(len(groups[g_ind])):
+                g_indices_w_y.append([i, group_positions[g_ind][i][1]])
+
+            sorted_indices = sorted(g_indices_w_y, key=lambda x: x[1])
+            # logging.info('sorted: {}'.format(sorted_indices))
+
+            for pair in sorted_indices:
+                onRight = True
+                i = pair[0]
+                for j in range(len(groups[g_ind])):
+                    if j != i and group_positions[g_ind][j][0] > group_positions[g_ind][i][0] and np.abs(group_positions[g_ind][j][1] - group_positions[g_ind][i][1]) < threshold:
+                        onRight = False
+                if onRight:
+                    side.append(i)
+            
+
+            return side
+        
+        def find_top(g_ind):
+            side = [] # bottom to top
+            g_indices_w_x = [] # indices of individuals in the GROUPS OBJECT, so not the ind of the agent, but the ind of the ind of the agent in the group
+            for i in range(len(groups[g_ind])):
+                g_indices_w_x.append([i, group_positions[g_ind][i][0]])
+
+            sorted_indices = sorted(g_indices_w_x, key=lambda x: x[1])
+
+            for pair in reversed(sorted_indices):
+                onRight = True
+                ind = pair[0]
+                for j in range(len(groups[g_ind])):
+                    if j != ind and group_positions[g_ind][j][1] > group_positions[g_ind][ind][1] and np.abs(group_positions[g_ind][j][0] - group_positions[g_ind][ind][0]) < threshold:
+                        onRight = False
+                if onRight:
+                    side.append(ind)
+            
+            return side
+
+        def find_left_side(g_ind):
+            side = [] # bottom to top
+            g_indices_w_y = [] # indices of individuals in the GROUPS OBJECT, so not the ind of the agent, but the ind of the ind of the agent in the group
+            for i in range(len(groups[g_ind])):
+                g_indices_w_y.append([i, group_positions[g_ind][i][1]])
+
+            sorted_indices = sorted(g_indices_w_y, key=lambda x: x[1])
+
+            for pair in reversed(sorted_indices):
+                onRight = True
+                ind = pair[0]
+                for j in range(len(groups[g_ind])):
+                    if j != ind and group_positions[g_ind][j][0] < group_positions[g_ind][ind][0] and np.abs(group_positions[g_ind][j][1] - group_positions[g_ind][ind][1]) < threshold:
+                        onRight = False
+                if onRight:
+                    side.append(ind)
+            
+            return side
+        
+        def find_bottom(g_ind):
+            side = [] # bottom to top
+            g_indices_w_x = [] # indices of individuals in the GROUPS OBJECT, so not the ind of the agent, but the ind of the ind of the agent in the group
+            for i in range(len(groups[g_ind])):
+                g_indices_w_x.append([i, group_positions[g_ind][i][1]])
+
+            sorted_indices = sorted(g_indices_w_x, key=lambda x: x[1])
+
+            for pair in sorted_indices:
+                onRight = True
+                i = pair[0]
+                for j in range(len(groups[g_ind])):
+                    if j != i and group_positions[g_ind][j][1] < group_positions[g_ind][i][1] and np.abs(group_positions[g_ind][j][0] - group_positions[g_ind][i][0]) < threshold:
+                        onRight = False
+                if onRight:
+                    side.append(i)
+            
+            return side
+        
+        right = find_right_side(g_index)
+        top = find_top(g_index) 
+        left = find_left_side(g_index) 
+        bottom = find_bottom(g_index)
+
+        return right, top, left, bottom
+


### PR DESCRIPTION
*** NOTE: This is intended to be added as a separate branch of the repo, however I do not have access to create a branch. Submitting for review primarily to satisfy 490 requirements, I believe it is best to resubmit once another branch is created on the main repo.***

Adding various work implementing and adapting different existing works relating to Game Theory and Topology driven social navigation, as well as social group clustering and space generation, detailed in the various READMEs. This code has been tested on my local version of ComplexityNav using Python 3.8.5.

Added 'crowd_nav/policy/brne' directory with README which contains an implementation/adaptation of BRNE for the complexityNav environment. 

Added 'crowd_nav/policy/topology_mpc' directory with README which contains implementations of various topology-preserving MPCs (see README for details). 

Added 'crowd_sim/envs/grouping' directory with README which contains helper classes/functions for pedestrian grouping and group space generation. 

*Edited  'crowd_sim/envs/crowd_sim.py' to include grouping and group space for visualization. *This modification is why I recommend an alternate branch, as it is a nontrivial change to core simulation functionality

Edited 'crowd_sim/README.md'.